### PR TITLE
feat: Injetar chaves de API LLM com base no provedor, ajustar o PYTHONPATH do Dockerfile e atualizar as dependências do LangGraph.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONUNBUFFERED=1 \
     POETRY_HOME="/opt/poetry" \
     POETRY_VIRTUALENVS_CREATE=false \
     POETRY_NO_INTERACTION=1 \
-    PYTHONPATH="/app/src"
+    PYTHONPATH="/app"
 
 # Add poetry to PATH
 ENV PATH="$POETRY_HOME/bin:$PATH"
@@ -18,8 +18,8 @@ ENV PATH="$POETRY_HOME/bin:$PATH"
 # Install system dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl \
-        build-essential \
+    curl \
+    build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Poetry

--- a/poetry.lock
+++ b/poetry.lock
@@ -1337,21 +1337,21 @@ langchain-core = ">=1.0.0,<2.0.0"
 
 [[package]]
 name = "langgraph"
-version = "1.0.3"
+version = "1.0.5"
 description = "Building stateful, multi-actor applications with LLMs"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "langgraph-1.0.3-py3-none-any.whl", hash = "sha256:4a75146f09bd0d127a724876f4244f460c4c66353a993641bd641ed710cd010f"},
-    {file = "langgraph-1.0.3.tar.gz", hash = "sha256:873a6aae6be054ef52a05c463be363a46da9711405b1b14454d595f543b68335"},
+    {file = "langgraph-1.0.5-py3-none-any.whl", hash = "sha256:b4cfd173dca3c389735b47228ad8b295e6f7b3df779aba3a1e0c23871f81281e"},
+    {file = "langgraph-1.0.5.tar.gz", hash = "sha256:7f6ae59622386b60fe9fa0ad4c53f42016b668455ed604329e7dc7904adbf3f8"},
 ]
 
 [package.dependencies]
 langchain-core = ">=0.1"
 langgraph-checkpoint = ">=2.1.0,<4.0.0"
 langgraph-prebuilt = ">=1.0.2,<1.1.0"
-langgraph-sdk = ">=0.2.2,<0.3.0"
+langgraph-sdk = ">=0.3.0,<0.4.0"
 pydantic = ">=2.7.4"
 xxhash = ">=3.5.0"
 
@@ -1389,14 +1389,14 @@ langgraph-checkpoint = ">=2.1.0,<4.0.0"
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.2.9"
+version = "0.3.0"
 description = "SDK for interacting with LangGraph API"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "langgraph_sdk-0.2.9-py3-none-any.whl", hash = "sha256:fbf302edadbf0fb343596f91c597794e936ef68eebc0d3e1d358b6f9f72a1429"},
-    {file = "langgraph_sdk-0.2.9.tar.gz", hash = "sha256:b3bd04c6be4fa382996cd2be8fbc1e7cc94857d2bc6b6f4599a7f2a245975303"},
+    {file = "langgraph_sdk-0.3.0-py3-none-any.whl", hash = "sha256:c1ade483fba17ae354ee920e4779042b18d5aba875f2a858ba569f62f628f26f"},
+    {file = "langgraph_sdk-0.3.0.tar.gz", hash = "sha256:4145bc3c34feae227ae918341f66d3ba7d1499722c1ef4a8aae5ea828897d1d4"},
 ]
 
 [package.dependencies]
@@ -3591,4 +3591,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "e967f7bea7429a7d9606f4ea80347babf6159fb4f9af860a8fa61986b416d05d"
+content-hash = "6697cba9ecab2a8f6fac0eef13ff96b3eca1e73d7efac8827860785d36d84397"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "pydantic (>=2.12.4,<3.0.0)",
     "pydantic-settings (>=2.12.0,<3.0.0)",
     "python-dotenv (>=1.2.1,<2.0.0)",
-    "langchain-litellm (>=0.3.2,<0.4.0)"
+    "langchain-litellm (>=0.3.2,<0.4.0)",
+    "langgraph (>=1.0.5,<2.0.0)"
 ]
 
 

--- a/src/BMO/core/llm.py
+++ b/src/BMO/core/llm.py
@@ -72,6 +72,16 @@ def get_llm_client(
         "streaming": final_streaming,
         "temperature": final_temperature,
     }
+
+    # Inject API key if available
+    api_key: Optional[str] = None
+    if settings.LLM_PROVIDER == "openai":
+        api_key = settings.OPENAI_API_KEY
+    elif settings.LLM_PROVIDER == "anthropic":
+        api_key = settings.ANTHROPIC_API_KEY
+    
+    if api_key:
+        llm_config["api_key"] = api_key
     
     # Add any additional kwargs
     llm_config.update(additional_kwargs)


### PR DESCRIPTION
## Correção da execução via Docker e autenticação da API

Este PR resolve dois problemas críticos que impediam a execução local do projeto via Docker.

### 🐛 Correções

1.  **Erro de Importação (`ModuleNotFoundError`)**
    *   **Problema:** O container falhava ao iniciar com `No module named 'src'`.
    *   **Causa:** O `PYTHONPATH` no [Dockerfile](cci:7://file:///home/gran-3668/%C3%81rea%20de%20Trabalho/Projects/bmo/BMO/Dockerfile:0:0-0:0) estava apontando para `/app/src`, o que conflitava com os imports absolutos do projeto que começam com `src.` (ex: `from src.BMO...`).
    *   **Solução:** O `PYTHONPATH` foi ajustado para `/app` no Dockerfile.

2.  **Erro de Autenticação OpenAI (`AuthenticationError`)**
    *   **Problema:** O assistente falhava ao tentar responder mensagens devido à falta de credenciais na instância do `LiteLLM`.
    *   **Causa:** O cliente `ChatLiteLLM` não estava recebendo a [api_key](cci:1://file:///home/gran-3668/%C3%81rea%20de%20Trabalho/Projects/bmo/BMO/src/BMO/config/settings.py:114:4-122:16) explicitamente durante a inicialização, e a detecção automática via variável de ambiente falhava no contexto do Docker.
    *   **Solução:** O arquivo [src/BMO/core/llm.py](cci:7://file:///home/gran-3668/%C3%81rea%20de%20Trabalho/Projects/bmo/BMO/src/BMO/core/llm.py:0:0-0:0) foi modificado para injetar explicitamente a chave da API (obtida das configurações globais) na configuração do cliente.

### 🧪 Testes Realizados

*   [x] Build do Docker (`docker compose build bmo`) concluído com sucesso.
*   [x] Container inicia corretamente (`docker compose run --rm bmo`).
*   [x] Interação com o assistente (chat) funcionando sem erros de autenticação.