### PR TITLE
🛠️ PR: Gerenciamento de Sessões e Melhorias na Experiência da CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,20 @@ BMO is a modular AI Assistant built with Python, using **LangGraph** for orchest
    LLM_PROVIDER=openai
    LLM_MODEL=gpt-4o
    OPENAI_API_KEY=sk-your-key-here
-   DATABASE_URL=postgresql://user:pass@localhost:5432/bmo
+   # DATABASE_URL=postgresql://user:pass@localhost:5432/bmo (Optional, defaults to SQLite)
    ```
 
 ## 🏃 Usage
 
 1. **Run the Assistant:**
    ```bash
-   export PYTHONPATH=$PYTHONPATH:$(pwd)/src && poetry run python src/BMO/main.py
+   poetry run bmo
+   ```
+
+2. **Run with Persistence (Resume Conversations):**
+   To continue a previous conversation, use the `--session` argument:
+   ```bash
+   poetry run bmo --session minha-conversa
    ```
 
 ### 🐳 Running with Docker
@@ -63,14 +69,17 @@ You can also run BMO inside a Docker container.
 
 ## 🧩 Adding New Skills
 
-1. Create a new file in `src/BMO/skills/collection/`.
+BMO uses dynamic skill discovery. To add a new skill:
+
+1. Create a new file in `src/BMO/skills/collection/` (e.g., `my_skill.py`).
 2. Inherit from `BMO_skill`.
-3. Implement the `run` method and define `args_schema`.
-4. Register the skill at the end of the file:
+3. Implement the `run` method and define `args_schema` (a Pydantic model).
+4. Register the skill instance at the end of your file:
    ```python
+   from src.BMO.skills.registry import registry
    registry.register(MyNewSkill())
    ```
-5. Import your new skill file in `src/BMO/core/orchestrator.py` to ensure it is loaded.
+   *Note: BMO will automatically discover and load any skill file in the collection directory.*
 
 ## 📄 License
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -172,6 +172,22 @@ frozenlist = ">=1.1.0"
 typing-extensions = {version = ">=4.2", markers = "python_version < \"3.13\""}
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+description = "asyncio bridge to the standard sqlite3 module"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb"},
+    {file = "aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650"},
+]
+
+[package.extras]
+dev = ["attribution (==1.8.0)", "black (==25.11.0)", "build (>=1.2)", "coverage[toml] (==7.10.7)", "flake8 (==7.3.0)", "flake8-bugbear (==24.12.12)", "flit (==3.12.0)", "mypy (==1.19.0)", "ufmt (==2.8.0)", "usort (==1.0.8.post1)"]
+docs = ["sphinx (==8.1.3)", "sphinx-mdinclude (==0.6.2)"]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
@@ -1817,6 +1833,23 @@ files = [
 [package.dependencies]
 langchain-core = ">=0.2.38"
 ormsgpack = ">=1.12.0"
+
+[[package]]
+name = "langgraph-checkpoint-sqlite"
+version = "3.0.1"
+description = "Library with a SQLite implementation of LangGraph checkpoint saver."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "langgraph_checkpoint_sqlite-3.0.1-py3-none-any.whl", hash = "sha256:616124676e5827294966997ed853f5d41490cc61f73b3c79359f4ff307728508"},
+    {file = "langgraph_checkpoint_sqlite-3.0.1.tar.gz", hash = "sha256:c6580138e6abfd2ade7ea49186c664d47ef28dc44538674fa47e50a8a5f8af83"},
+]
+
+[package.dependencies]
+aiosqlite = ">=0.20"
+langgraph-checkpoint = ">=3,<4.0.0"
+sqlite-vec = ">=0.1.6"
 
 [[package]]
 name = "langgraph-prebuilt"
@@ -3683,6 +3716,21 @@ pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
+name = "sqlite-vec"
+version = "0.1.6"
+description = ""
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "sqlite_vec-0.1.6-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:77491bcaa6d496f2acb5cc0d0ff0b8964434f141523c121e313f9a7d8088dee3"},
+    {file = "sqlite_vec-0.1.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fdca35f7ee3243668a055255d4dee4dea7eed5a06da8cad409f89facf4595361"},
+    {file = "sqlite_vec-0.1.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b0519d9cd96164cd2e08e8eed225197f9cd2f0be82cb04567692a0a4be02da3"},
+    {file = "sqlite_vec-0.1.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:823b0493add80d7fe82ab0fe25df7c0703f4752941aee1c7b2b02cec9656cb24"},
+    {file = "sqlite_vec-0.1.6-py3-none-win_amd64.whl", hash = "sha256:c65bcfd90fa2f41f9000052bcb8bb75d38240b2dae49225389eca6c3136d3f0c"},
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.2"
 description = "Retry code until it succeeds"
@@ -4391,4 +4439,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "736b4f0416d87464126bd11fa0bf07ed6810366c40179b70fb106da03a7a9cce"
+content-hash = "e3cf2f2440d97fe178aa99402fa22add4e9df6e7b2365405a3717c0364cf3893"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,14 @@ dependencies = [
     "langchain-litellm (>=0.3.2,<0.4.0)",
     "langgraph (>=1.0.5,<2.0.0)",
     "ddgs (>=9.10.0,<10.0.0)",
+    "langgraph-checkpoint-sqlite (>=3.0.1,<4.0.0)",
 ]
+
+[tool.poetry]
+packages = [{include = "BMO", from = "src"}]
+
+[tool.poetry.scripts]
+bmo = "BMO.main:main"
 
 
 [build-system]

--- a/src/BMO/config/settings.py
+++ b/src/BMO/config/settings.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
     OLLAMA_BASE_URL: str = "http://localhost:11434"
     
     # Application Configuration
+    DATABASE_PATH: str = "persistence/bmo_history.sqlite"
     DATABASE_URL: Optional[str] = None
     SYSTEM_PROMPT: str = (
         "You are BMO, a helpful and modular AI Assistant. "
@@ -173,6 +174,23 @@ class Settings(BaseSettings):
         elif self.LLM_PROVIDER == "anthropic":
             required_keys["ANTHROPIC_API_KEY"] = self.ANTHROPIC_API_KEY
         return required_keys
+
+    @property
+    def EFFECTIVE_DATABASE_URL(self) -> str:
+        """Get the effective database URL or path."""
+        if self.DATABASE_URL:
+            return self.DATABASE_URL
+        return self.DATABASE_PATH
+
+    def ensure_database_dir(self) -> None:
+        """Ensure the directory for the database exists."""
+        db_dir = os.path.dirname(self.DATABASE_PATH)
+        if db_dir and not os.path.exists(db_dir):
+            try:
+                os.makedirs(db_dir, exist_ok=True)
+                logger.info(f"Created database directory: {db_dir}")
+            except OSError as e:
+                logger.error(f"Failed to create database directory {db_dir}: {e}")
 
     def is_configuration_valid(self) -> bool:
         """

--- a/src/BMO/main.py
+++ b/src/BMO/main.py
@@ -7,6 +7,7 @@ and response streaming with comprehensive error handling and user experience
 considerations.
 """
 
+import argparse
 import uuid
 import sys
 import signal
@@ -124,8 +125,14 @@ class BMOCLI:
     management, command processing, and graceful shutdown handling.
     """
     
-    def __init__(self):
-        """Initialize the CLI interface."""
+    def __init__(self, session_id: Optional[str] = None):
+        """
+        Initialize the CLI interface.
+        
+        Args:
+            session_id: Optional fixed session ID to use for persistence.
+        """
+        self.initial_session_id: Optional[str] = session_id
         self.session: Optional[BMOSession] = None
         self.running: bool = False
         self._setup_signal_handlers()
@@ -165,7 +172,7 @@ class BMOCLI:
         print("🚀 Initializing BMO Assistant...")
         
         try:
-            self.session: Optional[BMOSession] = BMOSession()
+            self.session: Optional[BMOSession] = BMOSession(session_id=self.initial_session_id)
             self.running: bool = True
             
             self._show_welcome_message()
@@ -321,15 +328,15 @@ Just type normally to chat with BMO!
 def main() -> None:
     """
     Main entry point for BMO Assistant CLI.
-    
-    This function initializes and starts the BMO CLI interface with
-    proper error handling and resource management.
-    
-    Example:
-        $ python -m src.BMO.main
-        🚀 Initializing BMO Assistant...
-        🤖 BMO Assistant Ready! (Session: abc123...)
     """
+    parser = argparse.ArgumentParser(description="BMO Assistant CLI")
+    parser.add_argument(
+        "--session", 
+        type=str, 
+        help="Custom session ID for persistence. Use the same name to continue a conversation."
+    )
+    args = parser.parse_args()
+
     try:
         # Configure logging based on settings
         logging.basicConfig(
@@ -337,10 +344,10 @@ def main() -> None:
             format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
         )
         
-        logger.info("Starting BMO Assistant CLI")
+        logger.info(f"Starting BMO Assistant CLI (Session: {args.session or 'New'})")
         
         # Create and start CLI
-        cli: BMOCLI = BMOCLI()
+        cli: BMOCLI = BMOCLI(session_id=args.session)
         cli.start()
         
     except Exception as e:

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,46 @@
+import sys
+import os
+import uuid
+from langchain_core.messages import HumanMessage
+
+# Add src to pythonpath
+sys.path.append(os.path.join(os.getcwd(), "src"))
+
+from src.BMO.core.orchestrator import build_graph
+
+def test_persistence():
+    session_id = f"test-session-{uuid.uuid4().hex[:8]}"
+    config = {"configurable": {"thread_id": session_id}}
+    
+    print(f"--- Session 1: Starting with thread_id: {session_id} ---")
+    graph1 = build_graph()
+    
+    # Send first message
+    print("User: Meu nome é Aang e eu moro em Ba Sing Se.")
+    input1 = {"messages": [HumanMessage(content="Meu nome é Aang e eu moro em Ba Sing Se.")]}
+    for event in graph1.stream(input1, config, stream_mode="values"):
+        pass # Wait for completion
+        
+    print("Session 1 finished and closed.")
+    
+    print(f"\n--- Session 2: Reopening with same thread_id: {session_id} ---")
+    # Re-build graph to simulate application restart
+    graph2 = build_graph()
+    
+    print("User: Qual é o meu nome e onde eu moro?")
+    input2 = {"messages": [HumanMessage(content="Qual é o meu nome e onde eu moro?")]}
+    
+    final_message = ""
+    for event in graph2.stream(input2, config, stream_mode="values"):
+        if "messages" in event:
+            final_message = event["messages"][-1].content
+            
+    print(f"BMO: {final_message}")
+    
+    if "Aang" in final_message and "Ba Sing Se" in final_message:
+        print("\n✅ Verification SUCCESS: BMO remembered the information across sessions!")
+    else:
+        print("\n❌ Verification FAILED: BMO forgot the information.")
+
+if __name__ == "__main__":
+    test_persistence()


### PR DESCRIPTION
Este PR introduz a capacidade de gerenciar sessões persistentes via linha de comando e simplifica significativamente a execução do BMO para o usuário final e desenvolvedores.

🚀 Principais Mudanças
1. Gerenciamento de Sessão via CLI (--session)

Atualizado o arquivo 
src/BMO/main.py
 para suportar o argumento opcional --session.
Agora é possível persistir e retomar conversas específicas usando um identificador (ex: poetry run bmo --session minha-conversa).
Se nenhum ID for fornecido, o BMO continua gerando sessões únicas aleatórias para garantir privacidade e isolamento.
2. Execução Facilitada com Poetry Scripts

Configurado o script bmo no 
pyproject.toml
.
Removida a necessidade de exportar manualmente o PYTHONPATH. Agora o assistente pode ser iniciado apenas com:
bash
poetry run bmo
3. Atualização da Documentação (README)

Documentada a nova funcionalidade de sessões.
Instruções de instalação e uso simplificadas.
Revisada a seção de "Como adicionar novas Skills" para refletir o sistema de descoberta automática de plugins implementado anteriormente.
Esclarecido que a configuração de 
DATABASE_URL
 no .env é opcional, com fallback seguro para SQLite.
4. Refinamento de Testes de Persistência

Atualizado o script 
tests/test_persistence.py
 com novos dados de validação ("Aang em Ba Sing Se") para garantir que o motor de persistência está respondendo corretamente a novos contextos.
🧪 Como Verificar
Instalação: Execute poetry install para registrar o novo comando.
Teste de Persistência:
Rode poetry run bmo --session teste.
Diga algo ao BMO (ex: "Meu cor favorito é azul").
Saia com /exit.
Rode novamente poetry run bmo --session teste e pergunte sua cor favorita.
Scripts de Teste: Rode PYTHONPATH=. poetry run python tests/test_persistence.py. (O script deve carregar o caminho configurado e passar na validação).
