### PR TITLE
🚀 PR: Camada de API, Postgres e otimização extrema do Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+venv/
+.venv/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+.pytest_cache/
+.coverage
+htmlcov/
+.mypy_cache/
+
+# Docker
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Environment & Private
+.env
+.env.*
+template.env
+persistence/
+
+# Project
+README.md
+docs/
+tests/
+scripts/
+.agent/
+.gemini/
+.cursor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,91 @@
-FROM python:3.11-slim
+# --- Stage 1: Build Base ---
+FROM python:3.11-slim as base
 
-# Set environment variables
+# Common environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PIP_NO_CACHE_DIR=off \
-    PIP_DISABLE_PIP_VERSION_CHECK=on \
-    PIP_DEFAULT_TIMEOUT=100 \
-    POETRY_VERSION=2.0.0 \
-    POETRY_HOME="/opt/poetry" \
-    POETRY_VIRTUALENVS_CREATE=false \
-    POETRY_NO_INTERACTION=1 \
-    PYTHONPATH="/app"
+    PYTHONFAULTHANDLER=1 \
+    PYTHONMALLOC=malloc \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
 
-# Add poetry to PATH
+# --- Stage 2: Builder ---
+FROM base as builder
+
+# Build configuration
+ENV POETRY_VERSION=2.0.0 \
+    POETRY_HOME="/opt/poetry" \
+    POETRY_VIRTUALENVS_CREATE=true \
+    POETRY_VIRTUALENVS_IN_PROJECT=true \
+    POETRY_NO_INTERACTION=1
+
 ENV PATH="$POETRY_HOME/bin:$PATH"
 
-# Install system dependencies
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+# Install system build dependencies using BuildKit cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
     curl \
     build-essential \
+    libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Poetry
 RUN curl -sSL https://install.python-poetry.org | python3 -
 
-# Set working directory
 WORKDIR /app
-
-# Copy dependency files
 COPY pyproject.toml poetry.lock ./
 
-# Install dependencies
-RUN poetry install --no-root
+# Install dependencies into project's .venv
+RUN --mount=type=cache,target=/root/.cache/pip \
+    poetry install --no-root --only main
 
-# Copy source code
-COPY src ./src
-COPY README.md .
+# --- Stage 3: Runner ---
+FROM base as runner
 
-# Entrypoint
-CMD ["python", "src/BMO/main.py"]
+LABEL org.opencontainers.image.title="BMO Assistant" \
+    org.opencontainers.image.description="Modular AI Assistant API Environment" \
+    org.opencontainers.image.version="0.1.0"
+
+# Install runtime dependencies and tini for signal handling
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+    tini \
+    libpq5 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a secure non-root user
+RUN addgroup --system --gid 1001 bmo && \
+    adduser --system --uid 1001 --gid 1001 --home /app bmo
+
+WORKDIR /app
+
+# Copy virtualenv from builder
+COPY --from=builder --chown=bmo:bmo /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Copy application source
+COPY --chown=bmo:bmo src ./src
+
+# Persistence setup
+RUN mkdir -p persistence && chown -R bmo:bmo persistence && chmod 700 persistence
+
+USER bmo
+
+# Runtime Configuration
+ENV PORT=8000 \
+    PYTHONPATH="/app"
+
+EXPOSE 8000
+
+# Healthcheck to ensure API is responsive
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8000/v1/health || exit 1
+
+# Use tini as init to handle signals correctly (SIGTERM, SIGINT)
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+# Start the uvicorn server in optimized production mode
+CMD ["uvicorn", "src.BMO.api.app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+.PHONY: help install run run-api shell test up down docker-logs clean
+
+# Variables
+PYTHON := poetry run python
+BMO := poetry run bmo
+API := poetry run uvicorn src.BMO.api.app:app
+
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+install: ## Install dependencies using Poetry
+	poetry install
+
+run: ## Run BMO Assistant CLI
+	$(BMO)
+
+run-api: ## Run BMO API Server (FastAPI)
+	$(API) --reload
+
+shell: ## Open BMO in interactive shell (CLI session)
+	$(BMO) --session interactive-shell
+
+test: ## Run all tests
+	poetry run pytest tests/
+
+persistence-test: ## Run specific persistence test
+	PYTHONPATH=src poetry run python tests/test_persistence.py
+
+up: ## Build and start production environment (Docker Compose)
+	docker compose up -d --build
+
+down: ## Stop production environment
+	docker compose down
+
+docker-logs: ## View Docker logs
+	docker compose logs -f bmo
+
+clean: ## Clean temporary files and caches
+	find . -type d -name "__pycache__" -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
+	rm -rf .pytest_cache .coverage htmlcov .mypy_cache
+	@echo "✨ Workspace cleaned!"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ BMO is a modular AI Assistant built with Python, using **LangGraph** for orchest
 - **LangGraph Orchestration**: Robust state management and agent workflows.
 - **LiteLLM Integration**: Support for 100+ LLMs (OpenAI, Anthropic, Ollama, etc.).
 - **Dynamic Plugin Registry**: Automatic skill discovery.
-- **HTTP API Layer**: Built with FastAPI, allowing easy integration with web and mobile frontends.
+- **HTTP API Layer**: Built with FastAPI for web/mobile integration.
+- **Production-Ready Docker**: Multi-stage builds, BuildKit caching, and `tini` for robust process management.
+- **Enterprise Persistence**: Support for both SQLite (local) and PostgreSQL (production).
+- **Automation Shortcuts**: `Makefile` included for rapid development and orchestration.
 
 ## 🛠️ Installation
 
@@ -18,19 +21,28 @@ BMO is a modular AI Assistant built with Python, using **LangGraph** for orchest
    cd BMO
    ```
 
-2. **Install dependencies with Poetry:**
+2. **Install dependencies:**
    ```bash
-   poetry install
+   make install
    ```
 
 3. **Configure Environment:**
-   Create a `.env` file in the root directory:
-   ```ini
-   LLM_PROVIDER=openai
-   LLM_MODEL=gpt-4o
-   OPENAI_API_KEY=sk-your-key-here
-   # DATABASE_URL=postgresql://user:pass@localhost:5432/bmo (Optional, defaults to SQLite)
+   ```bash
+   cp template.env .env
    ```
+
+## ⌨️ Shortcuts (Makefile)
+
+Use these commands for faster development:
+
+- `make run`: Starts the CLI.
+- `make run-api`: Starts the API server.
+- `make test`: Runs all tests.
+- `make up`: Starts the production environment (Postgres + API).
+- `make down`: Stops the production environment.
+- `make docker-logs`: View container logs.
+- `make clean`: Cleans up caches and temporary files.
+- `make help`: Shows all available commands.
 
 ## 🏃 Usage
 
@@ -38,52 +50,50 @@ BMO is a modular AI Assistant built with Python, using **LangGraph** for orchest
 
 1. **Run the Assistant:**
    ```bash
-   poetry run bmo
+   make run
    ```
 
 2. **Run with Persistence (Resume Conversations):**
-   To continue a previous conversation, use the `--session` argument:
    ```bash
-   poetry run bmo --session minha-conversa
+   make shell
    ```
+   *Note: This uses the `interactive-shell` session.*
 
 3. **Interact:**
-   Type your query in the terminal.
-   - Example: *"Hello, what is the OS of this machine?"*
-   - Type `/exit` or `/quit` to stop.
+   Type your query in the terminal. Use `/exit` to stop.
 
 ### API Mode (HTTP Server)
 
 1. **Run the API Server:**
    ```bash
-   poetry run uvicorn src.BMO.api.app:app --reload
+   make run-api
    ```
-   *The server will start at `http://localhost:8000`.*
 
 2. **Interactive Documentation:**
-   Open your browser at `http://localhost:8000/docs` to see the dynamic Swagger UI.
+   Open `http://localhost:8000/docs` for the Swagger UI.
 
 3. **Core Endpoints:**
-   - `POST /v1/chat`: Send a message and get an AI response.
-   - `GET /v1/history/{session_id}`: Retrieve message history for a specific session.
-   - `GET /v1/health`: Check status.
+   - `POST /v1/chat`: Message interaction.
+   - `GET /v1/history/{session_id}`: Context retrieval.
 
-### 🐳 Running with Docker
+### 🐳 Production with Docker
 
-You can also run BMO inside a Docker container.
+BMO is optimized for production containerization.
 
-1. **Using Docker Compose (Recommended):**
+1. **Using Docker Compose (PostgreSQL Persistent):**
    ```bash
-   docker compose run --rm bmo
+   make up
+   ```
+   *This starts the API server and a healthy PostgreSQL instance.*
+
+2. **View Logs:**
+   ```bash
+   make docker-logs
    ```
 
-2. **Using Docker directly:**
+3. **Manual Build:**
    ```bash
-   # Build the image
    docker build -t bmo .
-
-   # Run the container
-   docker run -it --env-file .env bmo
    ```
 
 ## 🧩 Adding New Skills
@@ -92,13 +102,12 @@ BMO uses dynamic skill discovery. To add a new skill:
 
 1. Create a new file in `src/BMO/skills/collection/` (e.g., `my_skill.py`).
 2. Inherit from `BMO_skill`.
-3. Implement the `run` method and define `args_schema` (a Pydantic model).
-4. Register the skill instance at the end of your file:
+3. Implement the `run` method and `args_schema`.
+4. Register the skill instance:
    ```python
    from src.BMO.skills.registry import registry
    registry.register(MyNewSkill())
    ```
-   *Note: BMO will automatically discover and load any skill file in the collection directory.*
 
 ## 📄 License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,31 @@
 services:
   bmo:
     build: .
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-bmo_user}:${POSTGRES_PASSWORD:-bmo_password}@db:5432/${POSTGRES_DB:-bmo_db}
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-bmo_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-bmo_password}
+      POSTGRES_DB: ${POSTGRES_DB:-bmo_db}
+    ports:
+      - "5433:5432"
     volumes:
-      - ./.env:/app/.env
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-bmo_user} -d ${POSTGRES_DB:-bmo_db}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1870,6 +1870,24 @@ langchain-core = ">=0.2.38"
 ormsgpack = ">=1.12.0"
 
 [[package]]
+name = "langgraph-checkpoint-postgres"
+version = "3.0.2"
+description = "Library with a Postgres implementation of LangGraph checkpoint saver."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "langgraph_checkpoint_postgres-3.0.2-py3-none-any.whl", hash = "sha256:15c0fb638edfbc54d496f1758d0327d1a081e0ef94dda8f0c91d4b307d6d8545"},
+    {file = "langgraph_checkpoint_postgres-3.0.2.tar.gz", hash = "sha256:448cb8ec245b6fe10171a0f90e9aa047e24a9d3febba6a914644b0c1323da158"},
+]
+
+[package.dependencies]
+langgraph-checkpoint = ">=2.1.2,<4.0.0"
+orjson = ">=3.10.1"
+psycopg = ">=3.2.0"
+psycopg-pool = ">=3.2.0"
+
+[[package]]
 name = "langgraph-checkpoint-sqlite"
 version = "3.0.1"
 description = "Library with a SQLite implementation of LangGraph checkpoint saver."
@@ -2942,6 +2960,113 @@ files = [
     {file = "propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237"},
     {file = "propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d"},
 ]
+
+[[package]]
+name = "psycopg"
+version = "3.3.2"
+description = "PostgreSQL database adapter for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "psycopg-3.3.2-py3-none-any.whl", hash = "sha256:3e94bc5f4690247d734599af56e51bae8e0db8e4311ea413f801fef82b14a99b"},
+    {file = "psycopg-3.3.2.tar.gz", hash = "sha256:707a67975ee214d200511177a6a80e56e654754c9afca06a7194ea6bbfde9ca7"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=4.6", markers = "python_version < \"3.13\""}
+tzdata = {version = "*", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+binary = ["psycopg-binary (==3.3.2) ; implementation_name != \"pypy\""]
+c = ["psycopg-c (==3.3.2) ; implementation_name != \"pypy\""]
+dev = ["ast-comments (>=1.1.2)", "black (>=24.1.0)", "codespell (>=2.2)", "cython-lint (>=0.16)", "dnspython (>=2.1)", "flake8 (>=4.0)", "isort-psycopg", "isort[colors] (>=6.0)", "mypy (>=1.19.0)", "pre-commit (>=4.0.1)", "types-setuptools (>=57.4)", "types-shapely (>=2.0)", "wheel (>=0.37)"]
+docs = ["Sphinx (>=5.0)", "furo (==2022.6.21)", "sphinx-autobuild (>=2021.3.14)", "sphinx-autodoc-typehints (>=1.12)"]
+pool = ["psycopg-pool"]
+test = ["anyio (>=4.0)", "mypy (>=1.19.0) ; implementation_name != \"pypy\"", "pproxy (>=2.7)", "pytest (>=6.2.5)", "pytest-cov (>=3.0)", "pytest-randomly (>=3.5)"]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.2"
+description = "PostgreSQL database adapter for Python -- C optimisation distribution"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "psycopg_binary-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0768c5f32934bb52a5df098317eca9bdcf411de627c5dca2ee57662b64b54b41"},
+    {file = "psycopg_binary-3.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:09b3014013f05cd89828640d3a1db5f829cc24ad8fa81b6e42b2c04685a0c9d4"},
+    {file = "psycopg_binary-3.3.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3789d452a9d17a841c7f4f97bbcba51a21f957ea35641a4c98507520e6b6a068"},
+    {file = "psycopg_binary-3.3.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44e89938d36acc4495735af70a886d206a5bfdc80258f95b69b52f68b2968d9e"},
+    {file = "psycopg_binary-3.3.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90ed9da805e52985b0202aed4f352842c907c6b4fc6c7c109c6e646c32e2f43b"},
+    {file = "psycopg_binary-3.3.2-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c3a9ccdfee4ae59cf9bf1822777e763bc097ed208f4901e21537fca1070e1391"},
+    {file = "psycopg_binary-3.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:de9173f8cc0efd88ac2a89b3b6c287a9a0011cdc2f53b2a12c28d6fd55f9f81c"},
+    {file = "psycopg_binary-3.3.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:0611f4822674f3269e507a307236efb62ae5a828fcfc923ac85fe22ca19fd7c8"},
+    {file = "psycopg_binary-3.3.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:522b79c7db547767ca923e441c19b97a2157f2f494272a119c854bba4804e186"},
+    {file = "psycopg_binary-3.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1ea41c0229f3f5a3844ad0857a83a9f869aa7b840448fa0c200e6bcf85d33d19"},
+    {file = "psycopg_binary-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:8ea05b499278790a8fa0ff9854ab0de2542aca02d661ddff94e830df971ff640"},
+    {file = "psycopg_binary-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:94503b79f7da0b65c80d0dbb2f81dd78b300319ec2435d5e6dcf9622160bc2fa"},
+    {file = "psycopg_binary-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:07a5f030e0902ec3e27d0506ceb01238c0aecbc73ecd7fa0ee55f86134600b5b"},
+    {file = "psycopg_binary-3.3.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e09d0d93d35c134704a2cb2b15f81ffc8174fd602f3e08f7b1a3d8896156cf0"},
+    {file = "psycopg_binary-3.3.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:649c1d33bedda431e0c1df646985fbbeb9274afa964e1aef4be053c0f23a2924"},
+    {file = "psycopg_binary-3.3.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5774272f754605059521ff037a86e680342e3847498b0aa86b0f3560c70963c"},
+    {file = "psycopg_binary-3.3.2-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d391b70c9cc23f6e1142729772a011f364199d2c5ddc0d596f5f43316fbf982d"},
+    {file = "psycopg_binary-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f3f601f32244a677c7b029ec39412db2772ad04a28bc2cbb4b1f0931ed0ffad7"},
+    {file = "psycopg_binary-3.3.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:0ae60e910531cfcc364a8f615a7941cac89efeb3f0fffe0c4824a6d11461eef7"},
+    {file = "psycopg_binary-3.3.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7c43a773dd1a481dbb2fe64576aa303d80f328cce0eae5e3e4894947c41d1da7"},
+    {file = "psycopg_binary-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5a327327f1188b3fbecac41bf1973a60b86b2eb237db10dc945bd3dc97ec39e4"},
+    {file = "psycopg_binary-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:136c43f185244893a527540307167f5d3ef4e08786508afe45d6f146228f5aa9"},
+    {file = "psycopg_binary-3.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a9387ab615f929e71ef0f4a8a51e986fa06236ccfa9f3ec98a88f60fbf230634"},
+    {file = "psycopg_binary-3.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3ff7489df5e06c12d1829544eaec64970fe27fe300f7cf04c8495fe682064688"},
+    {file = "psycopg_binary-3.3.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:9742580ecc8e1ac45164e98d32ca6df90da509c2d3ff26be245d94c430f92db4"},
+    {file = "psycopg_binary-3.3.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d45acedcaa58619355f18e0f42af542fcad3fd84ace4b8355d3a5dea23318578"},
+    {file = "psycopg_binary-3.3.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d88f32ff8c47cb7f4e7e7a9d1747dcee6f3baa19ed9afa9e5694fd2fb32b61ed"},
+    {file = "psycopg_binary-3.3.2-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:59d0163c4617a2c577cb34afbed93d7a45b8c8364e54b2bd2020ff25d5f5f860"},
+    {file = "psycopg_binary-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e750afe74e6c17b2c7046d2c3e3173b5a3f6080084671c8aa327215323df155b"},
+    {file = "psycopg_binary-3.3.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f26f113013c4dcfbfe9ced57b5bad2035dda1a7349f64bf726021968f9bccad3"},
+    {file = "psycopg_binary-3.3.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8309ee4569dced5e81df5aa2dcd48c7340c8dee603a66430f042dfbd2878edca"},
+    {file = "psycopg_binary-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c6464150e25b68ae3cb04c4e57496ea11ebfaae4d98126aea2f4702dd43e3c12"},
+    {file = "psycopg_binary-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:716a586f99bbe4f710dc58b40069fcb33c7627e95cc6fc936f73c9235e07f9cf"},
+    {file = "psycopg_binary-3.3.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc5a189e89cbfff174588665bb18d28d2d0428366cc9dae5864afcaa2e57380b"},
+    {file = "psycopg_binary-3.3.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:083c2e182be433f290dc2c516fd72b9b47054fcd305cce791e0a50d9e93e06f2"},
+    {file = "psycopg_binary-3.3.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:ac230e3643d1c436a2dfb59ca84357dfc6862c9f372fc5dbd96bafecae581f9f"},
+    {file = "psycopg_binary-3.3.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d8c899a540f6c7585cee53cddc929dd4d2db90fd828e37f5d4017b63acbc1a5d"},
+    {file = "psycopg_binary-3.3.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50ff10ab8c0abdb5a5451b9315538865b50ba64c907742a1385fdf5f5772b73e"},
+    {file = "psycopg_binary-3.3.2-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:23d2594af848c1fd3d874a9364bef50730124e72df7bb145a20cb45e728c50ed"},
+    {file = "psycopg_binary-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ea4fe6b4ead3bbbe27244ea224fcd1f53cb119afc38b71a2f3ce570149a03e30"},
+    {file = "psycopg_binary-3.3.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:742ce48cde825b8e52fb1a658253d6d1ff66d152081cbc76aa45e2986534858d"},
+    {file = "psycopg_binary-3.3.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e22bf6b54df994aff37ab52695d635f1ef73155e781eee1f5fa75bc08b58c8da"},
+    {file = "psycopg_binary-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8db9034cde3bcdafc66980f0130813f5c5d19e74b3f2a19fb3cfbc25ad113121"},
+    {file = "psycopg_binary-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:df65174c7cf6b05ea273ce955927d3270b3a6e27b0b12762b009ce6082b8d3fc"},
+    {file = "psycopg_binary-3.3.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9ca24062cd9b2270e4d77576042e9cc2b1d543f09da5aba1f1a3d016cea28390"},
+    {file = "psycopg_binary-3.3.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c749770da0947bc972e512f35366dd4950c0e34afad89e60b9787a37e97cb443"},
+    {file = "psycopg_binary-3.3.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:03b7cd73fb8c45d272a34ae7249713e32492891492681e3cf11dff9531cf37e9"},
+    {file = "psycopg_binary-3.3.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:43b130e3b6edcb5ee856c7167ccb8561b473308c870ed83978ae478613764f1c"},
+    {file = "psycopg_binary-3.3.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c1feba5a8c617922321aef945865334e468337b8fc5c73074f5e63143013b5a"},
+    {file = "psycopg_binary-3.3.2-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cabb2a554d9a0a6bf84037d86ca91782f087dfff2a61298d0b00c19c0bc43f6d"},
+    {file = "psycopg_binary-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:74bc306c4b4df35b09bc8cecf806b271e1c5d708f7900145e4e54a2e5dedfed0"},
+    {file = "psycopg_binary-3.3.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:d79b0093f0fbf7a962d6a46ae292dc056c65d16a8ee9361f3cfbafd4c197ab14"},
+    {file = "psycopg_binary-3.3.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:1586e220be05547c77afc326741dd41cc7fba38a81f9931f616ae98865439678"},
+    {file = "psycopg_binary-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:458696a5fa5dad5b6fb5d5862c22454434ce4fe1cf66ca6c0de5f904cbc1ae3e"},
+    {file = "psycopg_binary-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:04bb2de4ba69d6f8395b446ede795e8884c040ec71d01dd07ac2b2d18d4153d1"},
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.0"
+description = "Connection Pool for Psycopg"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "psycopg_pool-3.3.0-py3-none-any.whl", hash = "sha256:2e44329155c410b5e8666372db44276a8b1ebd8c90f1c3026ebba40d4bc81063"},
+    {file = "psycopg_pool-3.3.0.tar.gz", hash = "sha256:fa115eb2860bd88fce1717d75611f41490dec6135efb619611142b24da3f6db5"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.6"
+
+[package.extras]
+test = ["anyio (>=4.0)", "mypy (>=1.14)", "pproxy (>=2.7)", "pytest (>=6.2.5)", "pytest-cov (>=3.0)", "pytest-randomly (>=3.5)"]
 
 [[package]]
 name = "pycparser"
@@ -4046,6 +4171,19 @@ files = [
 typing-extensions = ">=4.12.0"
 
 [[package]]
+name = "tzdata"
+version = "2025.3"
+description = "Provider of IANA time zone data"
+optional = false
+python-versions = ">=2"
+groups = ["main"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1"},
+    {file = "tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -4513,4 +4651,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "5f5d529aebb3c58738e44beebe1620501e8b76219fa77484b12917678547d110"
+content-hash = "40fdee45b9fedb5c1577868da67b528c1b3cf9d127854f5e44777e716ae28297"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,10 @@ dependencies = [
     "langgraph (>=1.0.5,<2.0.0)",
     "ddgs (>=9.10.0,<10.0.0)",
     "langgraph-checkpoint-sqlite (>=3.0.1,<4.0.0)",
+    "langgraph-checkpoint-postgres (>=3.0.2,<4.0.0)",
     "fastapi (>=0.128.0,<0.129.0)",
     "uvicorn (>=0.40.0,<0.41.0)",
+    "psycopg-binary (>=3.3.2,<4.0.0)",
 ]
 
 [tool.poetry]

--- a/template.env
+++ b/template.env
@@ -1,0 +1,15 @@
+# BMO Configuration Template
+
+# LLM Provider Configuration
+LLM_PROVIDER=openai
+LLM_MODEL=gpt-4o-mini
+OPENAI_API_KEY=your-api-key-here
+
+# Database Configuration (Docker Compose Defaults)
+POSTGRES_USER=bmo_user
+POSTGRES_PASSWORD=bmo_password
+POSTGRES_DB=bmo_db
+DATABASE_URL=postgresql://bmo_user:bmo_password@db:5432/bmo_db
+
+# App Settings
+LOG_LEVEL=INFO


### PR DESCRIPTION
Este PR completa a Phase 2 do projeto BMO, transformando-o de uma ferramenta CLI em uma plataforma escalável e pronta para produção. Introduzimos uma camada de API robusta, suporte a banco de dados corporativo (PostgreSQL) e um ambiente de containerização seguindo os mais altos padrões de engenharia e segurança.

🛠️ Major Changes
FastAPI Integration: Implementada camada de API HTTP com endpoints estruturados para chat (/v1/chat), histórico (/v1/history) e monitoramento de saúde (/v1/health).
Dual-Backend Persistence: O orquestrador agora suporta alternância dinâmica entre SQLite (desenvolvimento local) e PostgreSQL (produção) via DATABASE_URL.
Advanced Docker Environment:
Multi-stage Builds: Separação total de builders e runtime, resultando em imagens leves e seguras.
Non-root Security: Aplicação executada sob o usuário bmo, seguindo o princípio de menor privilégio.
BuildKit Caching: Otimização drástica do tempo de build com cache de camadas para apt e pip.
Automation Layer (Makefile): Adicionado um 
Makefile
 completo para facilitar o DX (Developer Experience), centralizando comandos de execução, teste e orquestração.
🛡️ Technical Improvements (Senior Standards)
Signal Handling: Adicionado o tini como init process para garantir que o BMO responda corretamente a sinais de encerramento (SIGTERM).
Python Runtime Ops: Configurações de PYTHONFAULTHANDLER e PYTHONMALLOC para maior estabilidade em containers.
Docker-native Healthchecks: Monitoramento ativo da disponibilidade da API pelo daemon do Docker.
Rede Isolada: Configuração de rede interna no Docker Compose para comunicação segura entre App e Banco.
Documentação SOTA: 
README.md
 totalmente revitalizado e inclusão de 
template.env
.
🧪 How to Test
Produção (Docker):
Execute make up para subir o stack completo.
Verifique se o banco está pronto com make docker-logs.
Teste a API: curl http://localhost:8000/v1/health.
Desenvolvimento (CLI):
Execute `make run` para testar o modo terminal com persistência SQLite local.
Qualidade:
Execute `make test` para rodar a suíte completa de testes unitários e funcionais.
