### PR TITLE
🚀 Hardening do SkillRegistry & Atualização da Documentação

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,16 +113,20 @@ O BMO é otimizado para conteinerização em produção.
 
 ## 🧩 Adicionando Novas Skills
 
-O BMO utiliza descoberta dinâmica de habilidades. Para adicionar uma nova skill:
+O BMO utiliza um sistema de registro explícito para maior segurança e estabilidade. Para adicionar uma nova skill:
 
 1. Crie um novo arquivo em `src/BMO/skills/collection/` (ex: `minha_skill.py`).
-2. Herde de `BMO_skill`.
-3. Implemente o método `run` e o `args_schema`.
-4. Registre a instância da skill:
+2. Herde de `BMO_skill` e implemente o método `run` e o `args_schema`.
+3. Adicione sua classe de skill ao arquivo `src/BMO/skills/registry_manifest.py`:
    ```python
-   from src.BMO.skills.registry import registry
-   registry.register(MinhaNovaSkill())
+   from .collection.minha_skill import MinhaNovaSkill
+   
+   SKILL_CLASSES = [
+       # ... skills existentes
+       MinhaNovaSkill,
+   ]
    ```
+4. O sistema carregará a skill automaticamente na próxima inicialização.
 
 ## 📄 Licença
 

--- a/src/BMO/main.py
+++ b/src/BMO/main.py
@@ -35,6 +35,11 @@ class BMOSession:
         Initialize a new BMO session.
         """
         self.session_id: str = session_id or str(uuid.uuid4())
+        
+        # Explicitly load skill registry manifest
+        from src.BMO.skills.registry import load_manifest
+        load_manifest()
+        
         self.supervisor = Supervisor()
         self.message_history: List[BaseMessage] = []
         

--- a/src/BMO/orchestrator/planner.py
+++ b/src/BMO/orchestrator/planner.py
@@ -48,37 +48,36 @@ class Planner:
              chain = prompt | self.llm.with_structured_output(ExecutionPlan)
              
              try:
-                 plan = await chain.ainvoke({"input": user_prompt})
+                plan = await chain.ainvoke({"input": user_prompt})
              except Exception as e:
-                 print(f"❌ Structured Output Error: {e}")
-                 # Fallback to standard parsing
-                 fallback_prompt = ChatPromptTemplate.from_messages([
-                    ("system", system_prompt),
-                    ("human", "{input}"),
-                    ("human", "Format instructions:\n{format_instructions}")
-                 ])
-                 chain = fallback_prompt | self.llm
-                 
-                 print(f"⚠️  Falling back to manual parsing due to: {e}")
-                 raw = await chain.ainvoke({
-                     "input": user_prompt,
-                     "format_instructions": self.parser.get_format_instructions()
-                 })
-                 plan = self.parser.parse(raw.content)
-        else:
-             fallback_prompt = ChatPromptTemplate.from_messages([
+                print(f"❌ Structured Output Error: {e}")
+                # Fallback to standard parsing
+                fallback_prompt = ChatPromptTemplate.from_messages([
                 ("system", system_prompt),
                 ("human", "{input}"),
                 ("human", "Format instructions:\n{format_instructions}")
-             ])
-             chain = fallback_prompt | self.llm | self.parser
-             plan = await chain.ainvoke({
-                 "input": user_prompt,
-                 "format_instructions": self.parser.get_format_instructions()
-             })
+                ])
+                chain = fallback_prompt | self.llm
+                
+                print(f"⚠️  Falling back to manual parsing due to: {e}")
+                raw = await chain.ainvoke({
+                    "input": user_prompt,
+                    "format_instructions": self.parser.get_format_instructions()
+                })
+                plan = self.parser.parse(raw.content)
+        else:
+            fallback_prompt = ChatPromptTemplate.from_messages([
+            ("system", system_prompt),
+            ("human", "{input}"),
+            ("human", "Format instructions:\n{format_instructions}")
+            ])
+            chain = fallback_prompt | self.llm | self.parser
+            plan = await chain.ainvoke({
+                "input": user_prompt,
+                "format_instructions": self.parser.get_format_instructions()
+            })
              
         # Normalize plan if needed (structured output returns object, parser returns object)
-
         if not plan.steps:
              return ExecutionPlan(steps=[], strategy_rationale="No actionable steps found.")
         

--- a/src/BMO/orchestrator/supervisor.py
+++ b/src/BMO/orchestrator/supervisor.py
@@ -11,16 +11,15 @@ from ..agents.coder import CoderAgent
 from ..agents.critic import CriticAgent
 from .planner import Planner
 
-# Registry of available agents
-agents_map = {
-    "researcher": ResearcherAgent(),
-    "writer": WriterAgent(),
-    "coder": CoderAgent(),
-    "critic": CriticAgent()
-}
-
 class Supervisor:
     def __init__(self):
+        # Registry of available agents
+        self.agents_map = {
+            "researcher": ResearcherAgent(),
+            "writer": WriterAgent(),
+            "coder": CoderAgent(),
+            "critic": CriticAgent()
+        }
         self.planner = Planner()
         self.workflow = self._build_graph()
 
@@ -111,7 +110,7 @@ class Supervisor:
         # User Feedback: Visibility
         # print(f"🔄 Executing Step {idx+1}/{len(plan.steps)}: {step.agent} (Attempt {retry_idx + 1})")
 
-        agent = agents_map[step.agent]
+        agent = self.agents_map[step.agent]
         
         payload = {"instruction": step.instruction}
         if feedback:
@@ -152,7 +151,7 @@ class Supervisor:
         step = plan.steps[idx]
         
         # print(f"⚖️  Critic Reviewing Step {idx+1}...")
-        critic = agents_map["critic"]
+        critic = self.agents_map["critic"]
         
         msg = A2AMessage(
             correlation_id=state["correlation_id"],

--- a/src/BMO/scripts/verify_skill.py
+++ b/src/BMO/scripts/verify_skill.py
@@ -1,14 +1,13 @@
 import sys
 import os
 
-# Add src to path
-sys.path.append(os.path.join(os.getcwd(), "src"))
+# Add project root to path
+sys.path.append(os.getcwd())
 
-from src.BMO.skills.registry import registry
+from src.BMO.skills.registry import registry, load_manifest
 
-# Import to register
-import src.BMO.skills.collection.system_ops
-import src.BMO.skills.collection.web_search
+# Explicitly load manifest
+load_manifest()
 
 def verify(skill_name):
     print("Verifying Skill Registration...")
@@ -19,13 +18,31 @@ def verify(skill_name):
     if skill_name in tool_names:
         print(f"SUCCESS: '{skill_name}' is registered.")
         
-        # Test execution
+        # Test execution with appropriate arguments
         skill = registry.skills[skill_name]
-        result = skill.run(query="Test Query")
-        print(f"Skill Execution Result: {result}")
+        try:
+            if skill_name == "get_system_info":
+                result = skill.run(query="Test Query")
+            elif skill_name == "web_search":
+                result = skill.run(query="Test Query")
+            elif skill_name == "system_manager_files":
+                result = skill.run(path="test_bmo_verify.txt", action="create", content="Verification test")
+                # Clean up
+                skill.run(path="test_bmo_verify.txt", action="delete")
+            else:
+                result = "No test case for this skill"
+            
+            print(f"Skill Execution Result: {result}")
+        except Exception as e:
+            print(f"FAILURE: Skill execution failed: {e}")
+            sys.exit(1)
     else:
         print(f"FAILURE: '{skill_name}' is NOT registered.")
         sys.exit(1)
 
 if __name__ == "__main__":
-    verify("get_system_info")
+    tools = registry.get_tools_list()
+    tool_names = [t.name for t in tools]
+    for name in tool_names:
+        verify(name)
+        print("-" * 20)

--- a/src/BMO/skills/collection/system_ops.py
+++ b/src/BMO/skills/collection/system_ops.py
@@ -5,7 +5,6 @@ from typing import Dict, Any, Optional
 from pydantic import BaseModel, Field, ValidationError
 
 from src.BMO.skills.base import BMO_skill
-from src.BMO.skills.registry import registry
 
 
 class SystemInfoInput(BaseModel):
@@ -201,7 +200,3 @@ class SystemManagerFilesSkill(BMO_skill):
         if action in ["create", "write"]:
             return handler(path, content)
         return handler(path)
-
-# Auto-register skills with the registry
-registry.register(SystemInfoSkill())
-registry.register(SystemManagerFilesSkill())

--- a/src/BMO/skills/collection/web_search.py
+++ b/src/BMO/skills/collection/web_search.py
@@ -5,7 +5,6 @@ from pydantic import BaseModel, Field, ValidationError
 from ddgs import DDGS
 
 from src.BMO.skills.base import BMO_skill
-from src.BMO.skills.registry import registry
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -163,7 +162,3 @@ class WebSearchSkill(BMO_skill):
             self._max_results = max_results
         else:
             logger.warning(f"Invalid max_results value: {max_results}. Must be between 1-20.")
-
-
-# Auto-register the skill with the registry
-registry.register(WebSearchSkill())

--- a/src/BMO/skills/registry_manifest.py
+++ b/src/BMO/skills/registry_manifest.py
@@ -1,0 +1,11 @@
+from typing import List, Type
+from src.BMO.skills.base import BMO_skill
+from src.BMO.skills.collection.system_ops import SystemInfoSkill, SystemManagerFilesSkill
+from src.BMO.skills.collection.web_search import WebSearchSkill
+
+# List of allowed skill classes for explicit registration
+SKILL_CLASSES: List[Type[BMO_skill]] = [
+    SystemInfoSkill,
+    SystemManagerFilesSkill,
+    WebSearchSkill
+]


### PR DESCRIPTION
Este PR implementa uma mudança fundamental na forma como o BMO gerencia suas capacidades (skills), movendo de uma descoberta dinâmica (e potencialmente instável) para um sistema de registro explícito via manifesto. Além disso, o 
README.md
 foi atualizado para refletir estas mudanças de arquitetura.

🛠️ Mudanças Realizadas
Core / Skills
Novo Manifesto: Criação de 
src/BMO/skills/registry_manifest.py
 para listar explicitamente todas as classes de skills permitidas.
SkillRegistry Robustecido:
Remoção da lógica de importação dinâmica e descoberta automática de arquivos.
Implementação do método 
load_manifest()
 para injeção de dependência controlada.
Suporte aprimorado para tree shaking e redução de efeitos colaterais durante a importação.
Refatoração de Skills: Remoção das chamadas de auto-registro (registry.register(...)) de dentro dos arquivos individuais de skills, centralizando o controle no registro.
Orquestração & Inicialização
Supervisor: Ajuste na ordem de inicialização para garantir que o manifesto seja carregado antes que os agentes tentem acessar as ferramentas.
Entrypoints: Atualização do main.py e scripts de verificação para utilizar o novo fluxo de carregamento.
Documentação
README.md: Atualização da seção "Adicionando Novas Skills" para instruir os desenvolvedores sobre o novo padrão de registro no manifesto.
🧪 Como Testar
Execute make test para garantir que as ferramentas ainda são convertidas corretamente para o formato LangChain.
Inicie a CLI com make run e verifique nos logs se as skills estão sendo carregadas via manifesto.
Adicione uma skill fictícia ao diretório collection sem incluí-la no manifesto e verifique se ela não aparece na lista de ferramentas (comportamento esperado).
⚠️ Observações de Breaking Changes
Novas skills precisam ser adicionadas manualmente ao 
registry_manifest.py
, caso contrário não serão reconhecidas pelo sistema.